### PR TITLE
Fixed deprecated function

### DIFF
--- a/src/github_automation/cli/main.py
+++ b/src/github_automation/cli/main.py
@@ -84,7 +84,7 @@ def event_manager(**kwargs):
     return manager.run()
 
 
-@main.resultcallback()
+@main.result_callback()
 def exit_from_program(result=0, **kwargs):
     sys.exit(result)
 


### PR DESCRIPTION
The `resultcallback` function was deprecated and deleted from click as of version 8.0.1 ad was replaced by `result_callback`
Reference: https://github.com/pallets/click/pull/1848/files